### PR TITLE
fix(name): set or default the `name` property on functions and classes

### DIFF
--- a/REWRITE.md
+++ b/REWRITE.md
@@ -74,10 +74,25 @@ export function fn() {
 ```
 
 ```js
-$h_live.fn(); // hoisted decl (no tdz)
+// Rename function and hoist proxy assignment.
+Object.defineProperty($c_fn, 'name', { value: 'fn' }); \
+$h_live.fn($c_fn); \
 ...
 function $c_fn() {
   ...
-} \
-fn = $c_fn;
+}
+```
+
+## export default
+
+In order to properly assign the 'default' name to exported anonymous functions and classes, we rewrite:
+
+```js
+export default XXX;
+```
+
+to:
+
+```js
+const {default: $c_default} = {default: (XXX)}; $h_once.default($c_default);
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,17 @@ const makeModuleTransformer = (babelCore, importer) => {
       )
       .join(',')}]), ${js(sourceOptions.exportAlls)});`;
     preamble += sourceOptions.hoistedDecls
-      .map(([vname, cvname]) => `${h.HIDDEN_LIVE}.${vname}(${cvname || ''});`)
+      .map(([vname, cvname]) => {
+        let src = '';
+        if (cvname) {
+          // It's a function, so set its name property.
+          src = `Object.defineProperty(${cvname}, 'name', {value: ${js(
+            vname,
+          )}});`;
+        }
+        src += `${h.HIDDEN_LIVE}.${vname}(${cvname || ''});`;
+        return src;
+      })
       .join('');
 
     // The functor captures the SES `arguments`, which is definitely

--- a/test/test-export-default.js
+++ b/test/test-export-default.js
@@ -55,6 +55,12 @@ test('export default', async t => {
       `endowed modules`,
     );
 
+    const { default: Cls } = await evaluateModule(`\
+export default class { valueOf() { return 45; } }
+`);
+    t.equal(Cls.name, 'default', `default class export is stamped`);
+    t.equal(new Cls().valueOf(), 45, `valueOf returns properly`);
+
     const ns = await evaluateModule(`\
 export default arguments;`);
     t.equal(typeof ns.default, 'object', 'arguments is an object');


### PR DESCRIPTION
Also, more consistent rewriting of `export default` FunctionDeclaration
and ClassDeclaration.

Closes #6, closes #7, and closes #9