### PR TITLE
fix(evaluateModule): strip shebang comment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,9 @@ const makeModuleTransformer = (babelCore, importer) => {
       importSources: {},
       importDecls: [],
     };
+    if (moduleSource.startsWith('#!')) {
+      moduleSource = `//${moduleSource}`;
+    }
     const scriptSource = transformSource(moduleSource, sourceOptions);
 
     let preamble = sourceOptions.importDecls.join(',');

--- a/test/test-export-default.js
+++ b/test/test-export-default.js
@@ -61,6 +61,12 @@ export default class { valueOf() { return 45; } }
     t.equal(Cls.name, 'default', `default class export is stamped`);
     t.equal(new Cls().valueOf(), 45, `valueOf returns properly`);
 
+    t.deepEqual(
+      await evaluateModule('#! /usr/bin/env node\nexport default 123'),
+      { default: 123 },
+      `shebang comment works`,
+    );
+
     const ns = await evaluateModule(`\
 export default arguments;`);
     t.equal(typeof ns.default, 'object', 'arguments is an object');


### PR DESCRIPTION
Module sources should ignore the shebang comment, not copy it into the
resulting functor where it causes a syntax error.

Closes #8